### PR TITLE
Fix(Encrypt): Tag property "recipient" as NotNull

### DIFF
--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
@@ -18,6 +18,7 @@ import name.neuhalfen.projects.crypto.bouncycastle.openpgp.keys.keyrings.Keyring
 import org.bouncycastle.util.io.Streams;
 import org.slf4j.Logger;
 
+import javax.validation.constraints.NotNull;
 import java.io.*;
 import java.net.URI;
 import java.util.List;
@@ -77,6 +78,7 @@ public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output>
     @Schema(
         title = "The list of recipients the file will be generated."
     )
+    @NotNull
     @PluginProperty(dynamic = true)
     private List<String> recipients;
 


### PR DESCRIPTION
Setting an empty recipient list lead to a NullPointer exception.
As it can't take any default recipient, the property must be set.