### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
@@ -88,31 +88,35 @@ public class Decrypt extends AbstractPgp implements RunnableTask<Decrypt.Output>
         title = "Source file to decrypt",
         description = "Kestra internal storage URI or templated path to the encrypted message."
     )
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "source")
     private Property<String> from;
 
     @Schema(
         title = "Private key for decryption",
         description = "ASCII-armored secret key export such as `gpg --export-secret-key -a`; the first key ring found is used."
     )
+    @PluginProperty(group = "connection")
     private Property<String> privateKey;
 
     @Schema(
         title = "Passphrase for private key",
         description = "Leave empty for unprotected keys; required for most secret keys."
     )
+    @PluginProperty(group = "connection")
     protected Property<String> privateKeyPassphrase;
 
     @Schema(
         title = "Allowed signer public keys",
         description = "Optional list of ASCII-armored public keys used to verify one-pass signatures."
     )
+    @PluginProperty(group = "connection")
     private Property<List<String>> signUsersKey;
 
     @Schema(
         title = "Required signer user IDs",
         description = "If set, verification fails unless the signature user ID matches one of these values; ignored when no signature is present."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> requiredSignerUsers;
 
     @Override

--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
@@ -89,13 +89,14 @@ public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output>
         title = "Source file to encrypt",
         description = "Kestra internal storage URI or templated path to the cleartext file."
     )
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "source")
     private Property<String> from;
 
     @Schema(
         title = "Public key for encryption",
         description = "ASCII-armored export such as `gpg --export -a`; the first key ring found is used."
     )
+    @PluginProperty(group = "connection")
     private Property<String> key;
 
     @Schema(
@@ -103,30 +104,35 @@ public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output>
         description = "Required metadata for compatibility; values are not validated against the provided key."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> recipients;
 
     @Schema(
         title = "Public key used for signature metadata",
         description = "Optional ASCII-armored export; kept for compatibility with legacy plugin expectations."
     )
+    @PluginProperty(group = "connection")
     private Property<String> signPublicKey;
 
     @Schema(
         title = "Private key for signing",
         description = "ASCII-armored secret key used to sign the encrypted payload."
     )
+    @PluginProperty(group = "connection")
     private Property<String> signPrivateKey;
 
     @Schema(
         title = "Passphrase for signing key",
         description = "Leave empty if the signing key is not protected."
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> signPassphrase;
 
     @Schema(
         title = "User ID bound to the signature",
         description = "Required when signing; identifies the signing key within the secret key ring."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> signUser;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712