### PR TITLE
fix(docs): correct signUsersKey example to use public key

### DIFF
--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
@@ -76,7 +76,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     privateKeyPassphrase: my-passphrase
                     signUsersKey:
                       - |
-                        -----BEGIN PGP PRIVATE KEY BLOCK-----
+                        -----BEGIN PGP PUBLIC KEY BLOCK-----
                     requiredSignerUsers:
                       - signer@kestra.io
                 """


### PR DESCRIPTION
The example showed a PGP private key block, but signUsersKey expects public keys.
