### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
@@ -93,6 +93,7 @@ public class Decrypt extends AbstractPgp implements RunnableTask<Decrypt.Output>
         title = "Private key for decryption",
         description = "ASCII-armored secret key export such as `gpg --export-secret-key -a`; the first key ring found is used."
     )
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> privateKey;
 
@@ -100,6 +101,7 @@ public class Decrypt extends AbstractPgp implements RunnableTask<Decrypt.Output>
         title = "Passphrase for private key",
         description = "Leave empty for unprotected keys; required for most secret keys."
     )
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     protected Property<String> privateKeyPassphrase;
 

--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
@@ -117,6 +117,7 @@ public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output>
         title = "Private key for signing",
         description = "ASCII-armored secret key used to sign the encrypted payload."
     )
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")
     private Property<String> signPrivateKey;
 
@@ -124,6 +125,7 @@ public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output>
         title = "Passphrase for signing key",
         description = "Leave empty if the signing key is not protected."
     )
+    @ToString.Exclude
     @PluginProperty(secret = true, group = "advanced")
     protected Property<String> signPassphrase;
 


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Lombok @ToString exposes PGP private key and passphrase fields in Decrypt (`src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java:29`)
  - Fix: Added `@ToString.Exclude` on `privateKey` and `privateKeyPassphrase` fields to prevent Lombok-generated `toString()` from exposing PGP private key material and passphrases in logs or debug output.

- **HIGH** Lombok @ToString exposes PGP signing private key and passphrase fields in Encrypt (`src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java:27`)
  - Fix: Added `@ToString.Exclude` on `signPrivateKey` and `signPassphrase` fields to prevent Lombok-generated `toString()` from exposing PGP signing private key material and passphrases in logs or debug output.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-crypto/issues/105
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
