### PR TITLE
docs(crypto): mark required OpenPGP task inputs

### DIFF
--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Decrypt.java
@@ -84,14 +84,14 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 public class Decrypt extends AbstractPgp implements RunnableTask<Decrypt.Output> {
     @Schema(
         title = "Source file to decrypt",
-        description = "Kestra internal storage URI or templated path to the encrypted message."
+        description = "Kestra internal storage URI or templated path to the encrypted message. Required."
     )
     @PluginProperty(internalStorageURI = true, group = "source")
     private Property<String> from;
 
     @Schema(
         title = "Private key for decryption",
-        description = "ASCII-armored secret key export such as `gpg --export-secret-key -a`; the first key ring found is used."
+        description = "ASCII-armored secret key export such as `gpg --export-secret-key -a`; the first key ring found is used. Required."
     )
     @ToString.Exclude
     @PluginProperty(secret = true, group = "connection")

--- a/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
+++ b/src/main/java/io/kestra/plugin/crypto/openpgp/Encrypt.java
@@ -86,14 +86,14 @@ import lombok.experimental.SuperBuilder;
 public class Encrypt extends AbstractPgp implements RunnableTask<Encrypt.Output> {
     @Schema(
         title = "Source file to encrypt",
-        description = "Kestra internal storage URI or templated path to the cleartext file."
+        description = "Kestra internal storage URI or templated path to the cleartext file. Required."
     )
     @PluginProperty(internalStorageURI = true, group = "source")
     private Property<String> from;
 
     @Schema(
         title = "Public key for encryption",
-        description = "ASCII-armored export such as `gpg --export -a`; the first key ring found is used."
+        description = "ASCII-armored export such as `gpg --export -a`; the first key ring found is used. Required."
     )
     @PluginProperty(group = "connection")
     private Property<String> key;


### PR DESCRIPTION
## Documentation review: plugin-crypto

Task-level doc pass over the two tasks (`openpgp.Encrypt`, `openpgp.Decrypt`), `AbstractPgp`, the two metadata YAMLs, and the how-to doc. Documentation only; no runtime behavior changes.

### Fixes
- **`Encrypt`** — `from` and `key` are required at runtime (`run()` calls `.orElseThrow()`) but lack `@NotNull`, so added "Required." to their `@Schema` descriptions.
- **`Decrypt`** — same for `from` and `privateKey`.

Titles, descriptions, both examples per task (keys/passphrases via `{{ secret('...') }}`), secret handling (`signPrivateKey`/`signPassphrase`/`privateKey`/`privateKeyPassphrase` all `secret = true`), the metadata YAMLs, and the how-to were otherwise accurate. No `@Metric` declared or emitted.

---

## 🚩 Engineering flag list (not addressed here — code changes)

### ⚠️ `Decrypt` does not actually verify signatures (security)
The `Decrypt` class description ("verifies a one-pass signature and can enforce specific signer user IDs"), the `signUsersKey`/`requiredSignerUsers` property docs, `index.yaml` ("signature validation"), `openpgp.yaml` ("signature verification"), and the how-to ("To verify the signature…") all advertise signature verification. But `Decrypt.run()`:
- reads the one-pass signature and feeds the plaintext through `sig.update(...)`, yet **never calls `sig.verify(...)`** (the trailing `PGPSignatureList` is never read), and
- **never references `requiredSignerUsers`** anywhere.

So a message with a wrong/tampered signature (or signed by a non-allowed user) still decrypts successfully. This is an incomplete implementation of a security feature — verification must be implemented (call `sig.verify()` against the trailing signature and enforce `requiredSignerUsers`) so the documented behavior holds. (Per docs-owner decision, the docs are intentionally kept describing the intended behavior rather than softened.)

### Other
- **`Encrypt.signPublicKey`** is declared and documented but never read in `run()` (signing uses `signPrivateKey` + `signUser`); the description already notes it's "kept for compatibility with legacy plugin expectations", but it's effectively a dead property.
- **`@NotNull` gaps** — `Encrypt.from`/`key` and `Decrypt.from`/`privateKey` are required at runtime (`orElseThrow`) but not annotated `@NotNull` (documented via "Required." here); consider `@NotNull` for schema/UI validation. Conversely, `Encrypt.recipients` is `@NotNull` but is not actually used for encryption (only the first key in `key` is), as its own description notes.